### PR TITLE
Removing the need of Timestamp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 defaultTasks 'clean','build'
 apply plugin: 'java'
 apply plugin: 'idea'
-sourceCompatibility = 1.5
+sourceCompatibility = 1.8
 ext.rundeckPluginVersion= '1.1'
 
 
@@ -54,10 +54,10 @@ dependencies {
     // add any third-party jar dependencies you wish to include in the plugin
     // using the `pluginLibs` configuration as shown here:
     
-    pluginLibs group: 'net.rcarz', name: 'jira-client', version: '0.3'
+    pluginLibs group: 'net.rcarz', name: 'jira-client', version: '0.5'
     
     //the compile dependency won't add the rundeck-core jar to the plugin contents
-    compile group: 'org.rundeck', name: 'rundeck-core', version: '1.6.2'
+    compile group: 'org.rundeck', name: 'rundeck-core', version: '3.0.12-20190114'
 }
 
 // task to copy plugin libs to output/lib dir

--- a/src/main/java/org/rundeck/plugins/notification/JiraNotification.java
+++ b/src/main/java/org/rundeck/plugins/notification/JiraNotification.java
@@ -13,7 +13,7 @@ import net.rcarz.jiraclient.JiraClient;
 import net.rcarz.jiraclient.JiraException;
 
 import java.sql.Timestamp;
-import java.util.Iterator;
+import java.util.Date;
 import java.util.Map;
 
 /**
@@ -86,7 +86,7 @@ public class JiraNotification implements NotificationPlugin {
         String jobgroup =  (!isBlank(groupPath.toString()) ? groupPath + "/" : "");
         String jobdesc = (String)jobdata.get("description");
         String emoticon = (trigger.equals("success") ? "(/)" : "(x)");
-        Timestamp date = (trigger.equals("running") ? (Timestamp)executionData.get("dateStarted") : (Timestamp)executionData.get("dateEnded"));
+        Date date = (trigger.equals("running") ? (Date)executionData.get("dateStarted") : (Date)executionData.get("dateEnded"));
 
         StringBuilder sb = new StringBuilder();
 

--- a/src/main/java/org/rundeck/plugins/notification/JiraNotification.java
+++ b/src/main/java/org/rundeck/plugins/notification/JiraNotification.java
@@ -12,7 +12,6 @@ import net.rcarz.jiraclient.Issue;
 import net.rcarz.jiraclient.JiraClient;
 import net.rcarz.jiraclient.JiraException;
 
-import java.sql.Timestamp;
 import java.util.Date;
 import java.util.Map;
 


### PR DESCRIPTION
**Describe Your Changes**
* Modified the plugin to simply create a Date object rather than creating a Timestamp object.
* Modified the Gradle build file to compile using Java 1.8 and use the latest dependencies. This includes `rundeck-core` and `jira-client`.
* Removed unused imports

This pull request is to resolve https://github.com/rundeck/rundeck/issues/4354

**Testing**

[ ] Verified this fix indeed works using RunDeck 3.0.12 manually

@ahonor I don't exactly know what the release pipeline process is or if automated tests are required. 

