### PR TITLE
- Update emoticon handling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .gradle
 build/
+.project
+.settings

--- a/src/main/java/org/rundeck/plugins/notification/JiraNotification.java
+++ b/src/main/java/org/rundeck/plugins/notification/JiraNotification.java
@@ -84,7 +84,25 @@ public class JiraNotification implements NotificationPlugin {
         Object jobname = jobdata.get("name");
         String jobgroup =  (!isBlank(groupPath.toString()) ? groupPath + "/" : "");
         String jobdesc = (String)jobdata.get("description");
-        String emoticon = (trigger.equals("success") ? "(/)" : "(x)");
+        String emoticon = "";
+        switch (trigger) {
+            case "success":
+                emoticon = "(/)";
+                break;
+            case "running":
+                emoticon = "(i)";
+                break;
+            case "start":
+                emoticon = "(i)";
+                break;
+            case "failure":
+                emoticon = "(x)";
+                break;
+            default:
+                emoticon = "(x)";
+                break;
+        }
+
         Date date = (trigger.equals("running") ? (Date)executionData.get("dateStarted") : (Date)executionData.get("dateEnded"));
 
         StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
**Changes**:
- Update emoticon handling. 
The problem was that if the `trigger` String was set to "running" or "start",
the emoticon printed in the jira comment was a red cross mark,
which suggests that an error occured, which is not always the case
Now, when `trigger` == "running" or "start", a blue information emoticon is printed.
- Update gitignore